### PR TITLE
Add Windows support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.*
 *.pyc
 *.egg-info
 build


### PR DESCRIPTION
Windows NDC uses a different date format and character encoding. Maybe it's based off locale and it's actually different for other Unix systems as well. If this is the case, I'll have to go back to the drawing board!

On the Python side of things, everything will still be UTF-8 and `datetime` objects.