### PR TITLE
More platform-independent date parsing

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,14 @@
+[[source]]
+
+url = "https://pypi.python.org/simple"
+verify_ssl = true
+name = "pypi"
+
+
+[packages]
+
+python-dateutil = "*"
+
+
+[dev-packages]
+

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,46 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "a9e99679482fa191870abb12c047ce9c9ed2d6497dce7326bb65c143c327d262"
+        },
+        "host-environment-markers": {
+            "implementation_name": "cpython",
+            "implementation_version": "3.4.3",
+            "os_name": "nt",
+            "platform_machine": "x86",
+            "platform_python_implementation": "CPython",
+            "platform_release": "7",
+            "platform_system": "Windows",
+            "platform_version": "6.1.7601",
+            "python_full_version": "3.4.3",
+            "python_version": "3.4",
+            "sys_platform": "win32"
+        },
+        "pipfile-spec": 6,
+        "requires": {},
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.python.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "python-dateutil": {
+            "hashes": [
+                "sha256:95511bae634d69bc7329ba55e646499a842bc4ec342ad54a8cdb65645a0aad3c",
+                "sha256:891c38b2a02f5bb1be3e4793866c8df49c7d19baabf9c1bad62547e0b4866aca"
+            ],
+            "version": "==2.6.1"
+        },
+        "six": {
+            "hashes": [
+                "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb",
+                "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9"
+            ],
+            "version": "==1.11.0"
+        }
+    },
+    "develop": {}
+}

--- a/ndc/__init__.py
+++ b/ndc/__init__.py
@@ -8,6 +8,7 @@ import platform
 import subprocess
 
 from datetime import datetime
+from dateutil.parser import parse as dateparse
 from os.path import expanduser
 
 
@@ -99,7 +100,8 @@ class NDC:
     def __parse(self, line):
         """Helper function for parsing output from list, and find."""
         args = line.split(self.DELIMITER)
-        args[-1] = datetime.strptime(args[-1], self.timestamp_fmt)
+        #args[-1] = datetime.strptime(args[-1], self.timestamp_fmt)
+        args[-1] = dateparse(args[-1])
         return tuple(args)
 
     def list(self, image, path='', partition=0):

--- a/ndc/__init__.py
+++ b/ndc/__init__.py
@@ -100,7 +100,6 @@ class NDC:
     def __parse(self, line):
         """Helper function for parsing output from list, and find."""
         args = line.split(self.DELIMITER)
-        #args[-1] = datetime.strptime(args[-1], self.timestamp_fmt)
         args[-1] = dateparse(args[-1])
         return tuple(args)
 

--- a/ndc/__init__.py
+++ b/ndc/__init__.py
@@ -69,10 +69,8 @@ class NDC:
     def __configure_platform(self):
         if platform.system() == 'Windows':
             self.encoding = 'shift-jis'
-            self.timestamp_fmt = '%Y/%m/%d %H:%M:%S'
         else:
             self.encoding = 'utf-8'
-            self.timestamp_fmt = '%a %b %d %H:%M:%S %Y'
 
     def __validate_bin_version(self):
         version = (subprocess


### PR DESCRIPTION
NDC outputs timestamps based on the system format, so we need a more flexible parser to avoid exceptions whenever NDC accesses a disk. I used the one in ```dateutil``` and it works on my Windows 10 64-bit and Windows 7 32-bit environments.